### PR TITLE
Implement output filename formatting

### DIFF
--- a/Hakyll/Convert/Blogger.hs
+++ b/Hakyll/Convert/Blogger.hs
@@ -21,7 +21,7 @@ import           Data.Text                    (Text)
 import qualified Data.Text                    as T
 import qualified Data.Text.Encoding           as T
 import           Data.Time                    (UTCTime)
-import           Data.Time.Format             (parseTimeM, formatTime, defaultTimeLocale)
+import           Data.Time.Format             (parseTimeM, defaultTimeLocale)
 
 import           Hakyll.Core.Compiler
 import           Hakyll.Core.Item
@@ -181,16 +181,13 @@ distill fp = DistilledPost
     tags = map (T.pack . catTerm)
          . filter (not . isBloggerCategory)
          . entryCategories
-    date x = T.pack $
-        case parseTime' =<< entryPublished x of
-            Nothing -> "1970-01-01"
-            Just  d -> formatTime' d
+    date x = case parseTime' =<< entryPublished x of
+                 Nothing -> fromJust $ parseTime' "1970-01-01T00:00:00Z"
+                 Just  d -> d
     parseTime' d = msum $ map (\f -> parseTimeM True defaultTimeLocale f d)
         [ "%FT%T%Q%z"  -- with time zone
         , "%FT%T%QZ"   -- zulu time
         ]
-    formatTime' :: UTCTime -> String
-    formatTime' = formatTime defaultTimeLocale "%FT%TZ" --for hakyll
 
 -- ---------------------------------------------------------------------
 -- odds and ends

--- a/Hakyll/Convert/Common.hs
+++ b/Hakyll/Convert/Common.hs
@@ -4,9 +4,12 @@
 module Hakyll.Convert.Common where
 
 import           Data.Data
+import           Data.Default
+import           Data.Maybe
 import           Data.Text                    (Text)
 import qualified Data.Text                    as T
 import           Data.Time.Clock              (UTCTime)
+import           Data.Time.Clock.POSIX        (posixSecondsToUTCTime)
 
 data DistilledPost = DistilledPost
     { dpUri   :: String
@@ -20,3 +23,13 @@ data DistilledPost = DistilledPost
     , dpDate  :: UTCTime
     }
   deriving (Data, Typeable)
+
+instance Default DistilledPost where
+  def = DistilledPost
+    { dpUri        = ""
+    , dpBody       = ""
+    , dpTitle      = Nothing
+    , dpTags       = []
+    , dpCategories = []
+    , dpDate       = posixSecondsToUTCTime 0
+    }

--- a/Hakyll/Convert/Common.hs
+++ b/Hakyll/Convert/Common.hs
@@ -6,6 +6,7 @@ module Hakyll.Convert.Common where
 import           Data.Data
 import           Data.Text                    (Text)
 import qualified Data.Text                    as T
+import           Data.Time.Clock              (UTCTime)
 
 data DistilledPost = DistilledPost
     { dpUri   :: String
@@ -16,6 +17,6 @@ data DistilledPost = DistilledPost
     --   interested in ignoring tags and just focusing on categories
     --   in cases where you have lots of little uninteresting tags.
     , dpCategories :: [Text]
-    , dpDate  :: Text
+    , dpDate  :: UTCTime
     }
-  deriving (Show, Data, Typeable)
+  deriving (Data, Typeable)

--- a/Hakyll/Convert/OutputFormat.hs
+++ b/Hakyll/Convert/OutputFormat.hs
@@ -1,0 +1,89 @@
+{-# LANGUAGE OverloadedStrings  #-}
+{-# LANGUAGE ViewPatterns       #-}
+module Hakyll.Convert.OutputFormat
+    (validOutputFormat, formatPath)
+  where
+
+import           Data.Default
+import           Data.Time.Format             (formatTime, defaultTimeLocale)
+import           System.FilePath
+
+import           Hakyll.Convert.Common
+
+import qualified Data.Text              as T
+import qualified Data.Map.Strict        as M
+
+validOutputFormat :: T.Text -> Bool
+validOutputFormat format
+  | T.null format = False
+  | otherwise =
+      case formatPath format def of
+        Just _  -> True
+        Nothing -> False
+
+formatPath :: T.Text -> DistilledPost -> Maybe T.Text
+formatPath format post = helper [] format >>= return.T.concat
+  where
+  helper acc input =
+    case T.uncons input of
+      Just ('%', rest) ->
+        case T.uncons rest of
+          Just (ch,  rest2) ->
+            if ch `M.member` acceptableFormats
+              then let formatter = acceptableFormats M.! ch
+                   in helper ((formatter post):acc) rest2
+              else Nothing
+      Just (ch,  rest) -> helper ((T.singleton ch):acc) rest
+      Nothing          -> Just $ reverse acc
+
+-- When adding a new format, don't forget to update the help message in
+-- tools/hakyll-convert.hs
+acceptableFormats :: M.Map Char (DistilledPost -> T.Text)
+acceptableFormats = M.fromList [
+    -- this lets users put literal percent sign in the format)
+    ('%', const $ T.singleton '%')
+
+  , ('o', fmtOriginalPath) -- original filepath, like 2016/01/02/blog-post.html
+  , ('s', fmtSlug)   -- original slug, i.e. "blog-post" from the example above
+  , ('y', fmtYear2)  -- publication year, 2 digits
+  , ('Y', fmtYear4)  -- publication year, 4 digits
+  , ('m', fmtMonth)  -- publication month
+  , ('d', fmtDay)    -- publication day
+  , ('H', fmtHour)   -- publication hour
+  , ('M', fmtMinute) -- publication minute
+  , ('S', fmtSecond) -- publication second
+  ]
+
+fmtOriginalPath post =
+    T.pack
+  . dropTrailingSlash
+  . dropExtensions
+  $ chopUri (dpUri post)
+  where
+    dropTrailingSlash = reverse . dropWhile (== '/') . reverse
+    chopUri (dropPrefix "http://" -> ("",rest)) =
+       -- carelessly assumes we can treat URIs like filepaths
+       joinPath $ drop 1 -- drop the domain
+                $ splitPath rest
+    chopUri u = error $
+       "We've wrongly assumed that blog post URIs start with http://, but we got: " ++ u
+
+    dropPrefix :: Eq a => [a] -> [a] -> ([a],[a])
+    dropPrefix (x:xs) (y:ys) | x == y    = dropPrefix xs ys
+    dropPrefix left right = (left,right)
+
+fmtSlug post =
+    T.reverse
+  . (T.takeWhile (/= '/'))
+  . T.reverse
+  $ fmtOriginalPath post
+
+fmtDate format = T.pack . (formatTime defaultTimeLocale format) . dpDate
+
+fmtYear2  = fmtDate "%y"
+fmtYear4  = fmtDate "%Y"
+fmtMonth  = fmtDate "%m"
+fmtDay    = fmtDate "%d"
+fmtHour   = fmtDate "%H"
+fmtMinute = fmtDate "%M"
+fmtSecond = fmtDate "%S"

--- a/Hakyll/Convert/Wordpress.hs
+++ b/Hakyll/Convert/Wordpress.hs
@@ -56,13 +56,11 @@ distill item = DistilledPost
         }
     --
     date = case parseTime' =<< rssItemPubDate item of
-               Nothing -> "1970-01-01"
-               Just d  -> T.pack (formatTime' d)
+               Nothing -> fromJust $ parseTime' "1970-01-01T00:00:00Z"
+               Just  d -> d
     parseTime' d = msum $ map (\f -> parseTimeM True defaultTimeLocale f d)
         [ rfc822DateFormat
         ]
-    formatTime' :: UTCTime -> String
-    formatTime' = formatTime defaultTimeLocale "%FT%TZ" --for hakyll
 
 -- ---------------------------------------------------------------------
 -- helpers

--- a/README.markdown
+++ b/README.markdown
@@ -10,7 +10,9 @@ We aim to
   HTML and should stay as such without passing through filters)
 * allow for the possibility of [Cool URIs][cool-uris] by keeping
   relative page names the same as on your old blog (this only works
-  if you use your own domain for your hosted site)
+  if you use your own domain for your hosted site). If you don't agree with us
+  on that point, use `--output-format` flag to specify your own output filename
+  format.
 
 [hakyll]:    http://jaspervdj.be/hakyll/
 [cool-uris]: http://www.w3.org/Provider/Style/URI.html

--- a/hakyll-convert.cabal
+++ b/hakyll-convert.cabal
@@ -19,10 +19,14 @@ library
   exposed-modules:    Hakyll.Convert.Blogger
                  ,    Hakyll.Convert.Common
                  ,    Hakyll.Convert.Wordpress
+                 ,    Hakyll.Convert.OutputFormat
   build-depends:       base
                ,       binary
                ,       bytestring
+               ,       containers
+               ,       data-default
                ,       feed
+               ,       filepath
                ,       hakyll
                ,       text
                ,       time

--- a/hakyll-convert.cabal
+++ b/hakyll-convert.cabal
@@ -40,4 +40,5 @@ executable hakyll-convert
                ,       filepath
                ,       hakyll-convert
                ,       text
+               ,       time
                ,       xml

--- a/tools/hakyll-convert.hs
+++ b/tools/hakyll-convert.hs
@@ -14,6 +14,7 @@ import           Data.Maybe
 import           Data.Monoid
 import qualified Data.Text              as T
 import qualified Data.Text.Encoding     as T
+import           Data.Time.Format             (formatTime, defaultTimeLocale)
 import           System.Directory
 import           System.Environment
 import           System.FilePath
@@ -121,7 +122,7 @@ savePost cfg ext post = do
         "untitled (" <> T.unwords firstFewWords <> "…)"
       where
         firstFewWords = T.splitOn "-" . T.pack $ takeFileName postPath
-    formatDate  = id
+    formatDate  = T.pack . formatTime defaultTimeLocale "%FT%TZ" --for hakyll
     formatTags  = T.intercalate ","
     formatBody  = id
 

--- a/tools/hakyll-convert.hs
+++ b/tools/hakyll-convert.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE OverloadedStrings  #-}
-{-# LANGUAGE ViewPatterns       #-}
 
 import           Control.Applicative
 import           Control.Arrow
@@ -29,6 +28,7 @@ import           Text.Atom.Feed.Import
 import           Text.XML.Light
 
 import           Hakyll.Convert.Common
+import           Hakyll.Convert.OutputFormat
 import qualified Hakyll.Convert.Blogger   as Blogger
 import qualified Hakyll.Convert.Wordpress as Wordpress
 
@@ -36,20 +36,40 @@ data InputFormat = Blogger | Wordpress
   deriving (Data, Typeable, Enum, Show)
 
 data Config = Config
-    { feed      :: FilePath
-    , outputDir :: FilePath
-    , format    :: InputFormat
+    { feed          :: FilePath
+    , outputDir     :: FilePath
+    -- underscore will be turned into a dash when generating a commandline
+    -- option
+    , output_format :: T.Text
+    , format        :: InputFormat
     }
  deriving (Show, Data, Typeable)
 
 parameters :: FilePath -> Config
 parameters p = modes
     [ Config
-        { feed         = def &= argPos 0 &= typ "ATOM/RSS FILE"
-        , outputDir    = def &= argPos 1 &= typDir
-        , format       = Blogger &= help "blogger or wordpress"
+        { feed          = def &= argPos 0 &= typ "ATOM/RSS FILE"
+        , outputDir     = def &= argPos 1 &= typDir
+        , output_format = "%o" &= help outputFormatHelp
+        , format        = Blogger &= help "blogger or wordpress"
         } &= help "Save blog posts Blogger feed into individual posts"
     ] &= program (takeFileName p)
+
+outputFormatHelp = unlines [
+    "Output filenames format (without extension)"
+  , "Default: %o"
+  , "Available formats:"
+  , "  %% - literal percent sign"
+  , "  %o - original filename (e.g. 2016/01/02/blog-post)"
+  , "  %s - original slug (e.g. \"blog-post\")"
+  , "  %y - publication year, 2 digits"
+  , "  %Y - publication year, 4 digits"
+  , "  %m - publication month"
+  , "  %d - publication day"
+  , "  %H - publication hour"
+  , "  %M - publication minute"
+  , "  %S - publication second"
+  ]
 
 -- ---------------------------------------------------------------------
 --
@@ -58,9 +78,14 @@ parameters p = modes
 main = do
     p      <- getProgName
     config <- cmdArgs (parameters p)
-    case format config of
-        Blogger   -> mainBlogger   config
-        Wordpress -> mainWordPress config
+
+    let ofmt = output_format config
+
+    if not (T.null ofmt || validOutputFormat ofmt)
+      then fail $ "Invalid output format string: `" ++ T.unpack (output_format config) ++ "'"
+      else case format config of
+               Blogger   -> mainBlogger   config
+               Wordpress -> mainWordPress config
 
 mainBlogger :: Config -> IO ()
 mainBlogger config = do
@@ -105,17 +130,7 @@ savePost cfg ext post = do
     odir  = outputDir cfg
     --
     fname    = odir </> postPath <.> ext
-    postPath = dropTrailingSlash
-             . dropExtensions
-             $ chopUri (dpUri post)
-      where
-        dropTrailingSlash = reverse . dropWhile (== '/') . reverse
-        chopUri (dropPrefix "http://" -> ("",rest)) =
-           -- carelessly assumes we can treat URIs like filepaths
-           joinPath $ drop 1 -- drop the domain
-                    $ splitPath rest
-        chopUri u = error $
-           "We've wrongly assumed that blog post URIs start with http://, but we got: " ++ u
+    postPath = T.unpack $ fromJust $ formatPath (output_format cfg) post
     --
     formatTitle (Just t) = t
     formatTitle Nothing  =
@@ -125,33 +140,3 @@ savePost cfg ext post = do
     formatDate  = T.pack . formatTime defaultTimeLocale "%FT%TZ" --for hakyll
     formatTags  = T.intercalate ","
     formatBody  = id
-
-{-
--- Ugh! convert br tags inside of pre tags
-fixupBloggerHtml :: Content -> Content
-fixupBloggerHtml = descendElem $ \e ->
-    if elName e == unqual "pre"
-       then Just . Elem $
-                e { elContent = map (descendElem fixBr) (elContent e) }
-       else Nothing
-  where
-    fixBr e =
-       if elName e == unqual "br"
-          then Just (Text newline)
-          else Nothing
-    newline = CData CDataRaw "\n" Nothing
-
-descendElem pred (Elem e) =
-   case pred e of
-       Nothing -> Elem $ e  { elContent = map (descendElem pred) (elContent e) }
-       Just e2 -> e2
-descendElem _ x = x
--}
-
--- ---------------------------------------------------------------------
--- utilities
--- ---------------------------------------------------------------------
-
-dropPrefix :: Eq a => [a] -> [a] -> ([a],[a])
-dropPrefix (x:xs) (y:ys) | x == y    = dropPrefix xs ys
-dropPrefix left right = (left,right)


### PR DESCRIPTION
It's now possible to export articles with names matching Hakyll's schema: just run `hakyll-convert --output-format "%Y-%d-%m-%s" …`.

(This is the second of three PRs I wanted to submit.)