### PR TITLE
Drop Hakyll dependency

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -22,7 +22,6 @@ dependencies:
   - directory
   - feed
   - filepath
-  - hakyll
   - text
   - time
   - xml

--- a/src/Hakyll/Convert/Blogger.hs
+++ b/src/Hakyll/Convert/Blogger.hs
@@ -23,9 +23,6 @@ import qualified Data.Text.Encoding           as T
 import           Data.Time                    (UTCTime)
 import           Data.Time.Format             (parseTimeM, defaultTimeLocale)
 
-import           Hakyll.Core.Compiler
-import           Hakyll.Core.Item
-import           Hakyll.Web.Template.Context
 import           Text.Atom.Feed
 import           Text.Atom.Feed.Export
 import           Text.Atom.Feed.Import


### PR DESCRIPTION
Turns out we aren't using Hakyll at all, so let's remove it from the deps, speeding up the build immensely.