### PR TITLE
Add Windows to CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,10 +7,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, macos-10.15]
+        plan:
+          - os: ubuntu-20.04
+            extra_stack_args: ""
+          - os: macos-10.15
+            extra_stack_args: ""
+          - os: windows-2019
+            # Skip golden tests since they depend on Unix line endings.
+            extra_stack_args: "--skip golden"
 
-    name: Stack on ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
+    name: Stack on ${{ matrix.plan.os }}
+    runs-on: ${{ matrix.plan.os }}
 
     steps:
       - uses: actions/checkout@v2
@@ -18,9 +25,9 @@ jobs:
       - name: Cache dependencies
         uses: actions/cache@v2
         with:
-          key: ${{ matrix.os }}-${{ hashFiles('package.yaml', 'stack.yaml', 'stack.yaml.lock') }}-r2
+          key: ${{ matrix.plan.os }}-${{ hashFiles('package.yaml', 'stack.yaml', 'stack.yaml.lock') }}-r2
           path:
             ~/.stack
 
       - name: Build
-        run: stack test --haddock --ghc-options '-Werror'
+        run: stack test --haddock --ghc-options '-Werror' ${{ matrix.plan.extra_stack_args }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Cache dependencies
         uses: actions/cache@v2
         with:
-          key: ${{ matrix.plan.os }}-${{ hashFiles('package.yaml', 'stack.yaml', 'stack.yaml.lock') }}-r2
+          key: ${{ matrix.plan.os }}-${{ hashFiles('package.yaml', 'stack.yaml', 'stack.yaml.lock') }}-r3
           path:
             ~/.stack
 


### PR DESCRIPTION
Golden tests are skipped because "golden values" contain Unix-style line
endings. Windows, of course, produces Windows-style CRNL, making the
tests fail.

Kudos to @ForNeVeR for helping me figure out the correct incantation to
pass Windows-specific flags to Stack.

Fixes #26.

I keep having issues with the cache: macOS job restores a cache and [immediately fails to run the compiler](https://github.com/Minoru/hakyll-convert/runs/1376162144), while Windows job [restores 0 bytes of cache](https://github.com/Minoru/hakyll-convert/runs/1376156472). That's why I bumped the "revision number" of the cache key.