### PR TITLE
Allow bytestring 0.12

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -44,7 +44,7 @@ library:
     - Hakyll.Convert.OutputFormat
     - Hakyll.Convert.Wordpress
   dependencies:
-    - bytestring >= 0.10 && < 0.12
+    - bytestring >= 0.10 && < 0.13
     - containers >= 0.6 && < 0.7
     - data-default >= 0.7 && < 0.8
     - directory >= 1.3 && < 1.4
@@ -71,7 +71,7 @@ tests:
     dependencies:
       - hakyll-convert
 
-      - bytestring >= 0.10 && < 0.12
+      - bytestring >= 0.10 && < 0.13
       - data-default >= 0.7 && < 0.8
       - feed >= 1.3 && < 1.4
       - filepath >= 1.4 && < 1.5


### PR DESCRIPTION
Tested with `for action in build test ; do cabal $action --enable-tests --constrain 'bytestring == 0.12.0.2' || break ; done`.