### PR TITLE
Allow filepath 1.5

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -49,7 +49,7 @@ library:
     - data-default >= 0.7 && < 0.8
     - directory >= 1.3 && < 1.4
     - feed >= 1.3 && < 1.4
-    - filepath >= 1.4 && < 1.5
+    - filepath >= 1.4 && < 1.6
     - time >= 1.9 && < 1.13
     - xml-conduit >= 1.9 && < 1.10
 
@@ -60,7 +60,7 @@ executable:
     - hakyll-convert
 
     - cmdargs >= 0.10 && < 0.11
-    - filepath >= 1.4 && < 1.5
+    - filepath >= 1.4 && < 1.6
 
 tests:
   golden:
@@ -74,7 +74,7 @@ tests:
       - bytestring >= 0.10 && < 0.13
       - data-default >= 0.7 && < 0.8
       - feed >= 1.3 && < 1.4
-      - filepath >= 1.4 && < 1.5
+      - filepath >= 1.4 && < 1.6
       - tasty >= 1.2 && < 1.6
       - tasty-golden >= 2.3 && < 2.4
       - temporary >= 1.3 && < 1.4
@@ -91,7 +91,7 @@ tests:
       - data-default >= 0.7 && < 0.8
       - directory >= 1.3 && < 1.4
       - feed >= 1.3 && < 1.4
-      - filepath >= 1.4 && < 1.5
+      - filepath >= 1.4 && < 1.6
       - tasty >= 1.2 && < 1.6
       - tasty-expected-failure >= 0.12.2 && < 0.13
       - tasty-hunit >= 0.10 && < 0.11


### PR DESCRIPTION
Tested with `hpack && for action in build test ; do cabal $action --enable-tests --constrain 'filepath == 1.5.2.0' || break ; done` with GHC 9.4.8 on Linux.