### PR TITLE
Allow text 2.1, fix GHC 9.8 build

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -30,7 +30,7 @@ category: Tools
 # the targets.
 dependencies:
   - base >= 4.13 && < 5
-  - text >= 1.2 && < 1.3 || == 2.0.*
+  - text >= 1.2 && < 1.3 || >= 2.0 && < 2.2
   - xml-types >= 0.3 && < 0.4
 
 ghc-options: -Wall

--- a/src/Hakyll/Convert/Blogger.hs
+++ b/src/Hakyll/Convert/Blogger.hs
@@ -4,10 +4,8 @@
 
 module Hakyll.Convert.Blogger (FullPost (..), readPosts, distill) where
 
-import Control.Arrow
 import Control.Monad
-import Data.Function
-import Data.List
+import qualified Data.Map as M
 import Data.Maybe
 import qualified Data.Text as T
 import Data.Time.Format (defaultTimeLocale, parseTimeM)
@@ -226,11 +224,7 @@ entryError e msg =
   error $ (T.unpack msg) ++ " [on entry " ++ (T.unpack (entryId e)) ++ "]\n" ++ show e
 
 buckets :: (Ord b) => (a -> b) -> [a] -> [(b, [a])]
-buckets f =
-  map (first head . unzip)
-    . groupBy ((==) `on` fst)
-    . sortBy (compare `on` fst)
-    . map (\x -> (f x, x))
+buckets f = M.toList . M.fromListWith (++) . (map (\x -> (f x, [x])))
 
 -- | Find all non-nested elements which are named `name`, starting with `root`.
 -- ("Non-nested" means we don't search sub-elements of an element that's named


### PR DESCRIPTION
This fixes the build with GHC 9.8: https://github.com/commercialhaskell/stackage/issues/7304

Also fix the following GHC 9.8 warning:

```
src/Hakyll/Convert/Blogger.hs:230:14: warning: [GHC-63394] [-Wx-partial]
    In the use of ‘head’
    (imported from Data.List, but defined in GHC.List):
    "This is a partial function, it throws an error on empty lists. Use pattern matching or Data.List.uncons instead. Consider refactoring to use Data.List.NonEmpty."
    |
230 |   map (first head . unzip)
    |              ^^^^
```