### PR TITLE
Allow time 1.14

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -50,7 +50,7 @@ library:
     - directory >= 1.3 && < 1.4
     - feed >= 1.3 && < 1.4
     - filepath >= 1.4 && < 1.6
-    - time >= 1.9 && < 1.13
+    - time >= 1.9 && < 1.15
     - xml-conduit >= 1.9 && < 1.10
 
 executable:
@@ -78,7 +78,7 @@ tests:
       - tasty >= 1.2 && < 1.6
       - tasty-golden >= 2.3 && < 2.4
       - temporary >= 1.3 && < 1.4
-      - time >= 1.9 && < 1.13
+      - time >= 1.9 && < 1.15
 
   spec:
     main: Main.hs
@@ -97,4 +97,4 @@ tests:
       - tasty-hunit >= 0.10 && < 0.11
       - tasty-quickcheck >= 0.10 && < 0.11
       - temporary >= 1.3 && < 1.4
-      - time >= 1.9 && < 1.13
+      - time >= 1.9 && < 1.15


### PR DESCRIPTION
Tested with GHC 9.8.2:

    hpack && for action in build test ; do cabal $action --enable-tests --constrain 'time == 1.14' --allow-newer=feed:time || break ; done